### PR TITLE
fix inbuilt microphone

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ If you have installed an SSD and a HDD in your T430, you can gain the advantages
 			[usb] USB3_PRW 0x0D (instant wake)
 				-> to have sleep working (original Rehabman code)
 
-			[audio] Audio Layout 28
+			[audio] Audio Layout 29
 				-> to work with the ALC269 kext (original Rehabman code)
 
 			[sys] IRQ Fix

--- a/high-resolution-dsdt-patch.txt
+++ b/high-resolution-dsdt-patch.txt
@@ -470,7 +470,7 @@ Method (_DSM, 4, NotSerialized)\n
     If (LEqual (Arg2, Zero)) { Return (Buffer() { 0x03 } ) }\n
     Return (Package()\n
     {\n
-        "layout-id", Buffer() { 28, 0x00, 0x00, 0x00 },\n
+        "layout-id", Buffer() { 29, 0x00, 0x00, 0x00 },\n
         "hda-gfx", Buffer() { "onboard-1" },\n
         "PinConfigurations", Buffer() { },\n
         //"MaximumBootBeepVolume", 77,\n

--- a/low-resolution-dsdt-patch.txt
+++ b/low-resolution-dsdt-patch.txt
@@ -470,7 +470,7 @@ Method (_DSM, 4, NotSerialized)\n
     If (LEqual (Arg2, Zero)) { Return (Buffer() { 0x03 } ) }\n
     Return (Package()\n
     {\n
-        "layout-id", Buffer() { 28, 0x00, 0x00, 0x00 },\n
+        "layout-id", Buffer() { 29, 0x00, 0x00, 0x00 },\n
         "hda-gfx", Buffer() { "onboard-1" },\n
         "PinConfigurations", Buffer() { },\n
         //"MaximumBootBeepVolume", 77,\n


### PR DESCRIPTION
This fixes the inbuilt microphone (audio is still working of course). With layout-id 28 you will only get  static noise, while layout id 29 has the correct microphone and audio configuration.

This fix has been proven to work as one can see on multiple pages regarding T430 Hackintosh.
e. g. https://www.tonymacx86.com/threads/guide-lenovo-t430-el-capitan.175935/page-47#post-1286023