### PR TITLE
fix acpi poller (thanks to Legetzu)

### DIFF
--- a/fan patch/ACPIPoller.kext/Contents/Info.plist
+++ b/fan patch/ACPIPoller.kext/Contents/Info.plist
@@ -51,7 +51,7 @@
 			<key>IOClass</key>
 			<string>org_rehabman_ACPIPoller</string>
 			<key>IONameMatch</key>
-			<string>FAN00000</string>
+			<string>MON0000</string>
 			<key>IOProviderClass</key>
 			<string>IOACPIPlatformDevice</string>
 			<key>Methods</key>


### PR DESCRIPTION
corrects the IONameMatch property so HWMonitor is not needed anymore for this patch to work.